### PR TITLE
Remove unnecessary loop

### DIFF
--- a/lib/ObjectPath.js
+++ b/lib/ObjectPath.js
@@ -42,10 +42,6 @@
 					} else {
 						c = str.indexOf(q+']', b);
 						if (c === -1) c = str.length;
-						while (str.slice(c - 1, c) === '\\' && b < str.length){
-							b++;
-							c = str.indexOf(q+']', b);
-						}
 						parts.push(str.slice(i + 2, c).replace(new RegExp('\\'+q,'g'), q));
 						i = (str.slice(c + 2, c + 3) === '.') ? c + 3 : c + 2;
 					}


### PR DESCRIPTION
Hey there! While reviewing this code, I noticed this loop that seems to never be used. I think that maybe there was a typo, since `str.slice(c - 1, c) === '\\'` can _never_ be true. This has been around since the initial commit of the project, so I'm not too sure why it was added.

Removing it doesn't break any tests, so I thought I'd make a PR. @mike-marcacci , is there any chance that you remember what this loop was intended to do? I know it's been a few years :)