### PR TITLE
Improve stringify() and parse() + full support of backslash

### DIFF
--- a/lib/ObjectPath.js
+++ b/lib/ObjectPath.js
@@ -1,9 +1,9 @@
 'use strict';
 
 ;!function(undefined) {
-	var r = {
-		'\'': /\\\'/g,
-		'"': /\\\"/g,
+	var regex = {
+		"'": /\\\'/g,
+		'"': /\\\"/g
 	};
 
 	var ObjectPath = {
@@ -14,44 +14,44 @@
 
 			var i = 0;
 			var parts = [];
-			var d, b, q, c;
-			while (i < str.length){
-				d = str.indexOf('.', i);
-				b = str.indexOf('[', i);
+			var dot, bracket, quote, closing;
+			while (i < str.length) {
+				dot = str.indexOf('.', i);
+				bracket = str.indexOf('[', i);
 
 				// we've reached the end
-				if (d === -1 && b === -1){
+				if (dot === -1 && bracket === -1) {
 					parts.push(str.slice(i, str.length));
 					i = str.length;
 				}
 
 				// dots
-				else if (b === -1 || (d !== -1 && d < b)) {
-					parts.push(str.slice(i, d));
-					i = d + 1;
+				else if (bracket === -1 || (dot !== -1 && dot < bracket)) {
+					parts.push(str.slice(i, dot));
+					i = dot + 1;
 				}
 
 				// brackets
 				else {
-					if (b > i){
-						parts.push(str.slice(i, b));
-						i = b;
+					if (bracket > i) {
+						parts.push(str.slice(i, bracket));
+						i = bracket;
 					}
-					q = str.slice(b+1, b+2);
-					if (q !== '"' && q !=='\'') {
-						c = str.indexOf(']', b);
-						if (c === -1) c = str.length;
-						parts.push(str.slice(i + 1, c));
-						i = (str.slice(c + 1, c + 2) === '.') ? c + 2 : c + 1;
+					quote = str.slice(bracket + 1, bracket + 2);
+					if (quote !== '"' && quote !== '\'') {
+						closing = str.indexOf(']', bracket);
+						if (closing === -1) closing = str.length;
+						parts.push(str.slice(i + 1, closing));
+						i = (str.slice(closing + 1, closing + 2) === '.') ? closing + 2 : closing + 1;
 					} else {
-						c = str.indexOf(q+']', b);
-						if (c === -1) c = str.length;
-						while (str.slice(c - 1, c) === '\\' && b < str.length){
-							b++;
-							c = str.indexOf(q+']', b);
+						closing = str.indexOf(quote + ']', bracket);
+						if (closing === -1) closing = str.length;
+						while (str.slice(closing - 1, closing) === '\\' && bracket < str.length) {
+							bracket++;
+							closing = str.indexOf(quote + ']', bracket);
 						}
-						parts.push(str.slice(i + 2, c).replace(r[q], q));
-						i = (str.slice(c + 2, c + 3) === '.') ? c + 3 : c + 2;
+						parts.push(str.slice(i + 2, closing).replace(regex[quote], quote));
+						i = (str.slice(closing + 2, closing + 3) === '.') ? closing + 3 : closing + 2;
 					}
 				}
 			}

--- a/lib/ObjectPath.js
+++ b/lib/ObjectPath.js
@@ -69,8 +69,10 @@
 
 			return arr.map(function(value, key) {
 				let property = value.toString();
-				if (/^[A-z_]\w*$/.exec(property)) { // str with only A-z0-9_ chars display `foo.bar`
+				if (/^[A-z_]\w*$/.exec(property)) { // str with only A-z0-9_ chars will display `foo.bar`
 					return (key !== 0) ? '.' + property : property;
+				} else if (/^\d+$/.exec(property)) { // str with only numbers will display `foo[0]`
+					return '[' + property + ']';
 				} else {
 					property = property.replace(regexp, '\\$1');
 					return '[' + quote + property + quote + ']';

--- a/lib/ObjectPath.js
+++ b/lib/ObjectPath.js
@@ -60,7 +60,7 @@
 
 		// root === true : auto calculate root; must be dot-notation friendly
 		// root String : the string to use as root
-		stringify: function(arr, quote){
+		stringify: function(arr, quote, forceQuote){
 			if(!Array.isArray(arr))
 				arr = [ arr ];
 
@@ -69,9 +69,9 @@
 
 			return arr.map(function(value, key) {
 				let property = value.toString();
-				if (/^[A-z_]\w*$/.exec(property)) { // str with only A-z0-9_ chars will display `foo.bar`
+				if (!forceQuote && /^[A-z_]\w*$/.exec(property)) { // str with only A-z0-9_ chars will display `foo.bar`
 					return (key !== 0) ? '.' + property : property;
-				} else if (/^\d+$/.exec(property)) { // str with only numbers will display `foo[0]`
+				} else if (!forceQuote && /^\d+$/.exec(property)) { // str with only numbers will display `foo[0]`
 					return '[' + property + ']';
 				} else {
 					property = property.replace(regexp, '\\$1');

--- a/lib/ObjectPath.js
+++ b/lib/ObjectPath.js
@@ -53,7 +53,9 @@
 							bracket++;
 							closing = str.indexOf(quote + ']', bracket);
 						}
-						parts.push(str.slice(i + 2, closing).replace(regex[quote], quote));
+						parts.push(str.slice(i + 2, closing).replace(regex[quote], quote).replace(/\\+/g, function (backslash) {
+							return new Array(Math.ceil(backslash.length / 2) + 1).join('\\');
+						}));
 						i = (str.slice(closing + 2, closing + 3) === '.') ? closing + 3 : closing + 2;
 					}
 				}
@@ -68,7 +70,7 @@
 				arr = [ arr ];
 
 			quote = (quote === '"') ? '"' : "'";
-			const regexp = new RegExp('(\\\\|' + quote + ')', 'g'); // regex => /(\\|')/g
+			var regexp = new RegExp('(\\\\|' + quote + ')', 'g'); // regex => /(\\|')/g
 
 			return arr.map(function(value, key) {
 				let property = value.toString();

--- a/lib/ObjectPath.js
+++ b/lib/ObjectPath.js
@@ -61,13 +61,21 @@
 		// root === true : auto calculate root; must be dot-notation friendly
 		// root String : the string to use as root
 		stringify: function(arr, quote){
-
 			if(!Array.isArray(arr))
-				arr = [arr.toString()];
+				arr = [ arr ];
 
-			quote = quote === '"' ? '"' : '\'';
+			quote = (quote === '"') ? '"' : "'";
+			const regexp = new RegExp('(\\\\|' + quote + ')', 'g'); // regex => /(\\|')/g
 
-			return arr.map(function(n){ return '[' + quote + (n.toString()).replace(new RegExp(quote, 'g'), '\\' + quote) + quote + ']'; }).join('');
+			return arr.map(function(value, key) {
+				let property = value.toString();
+				if (/^[A-z_]\w*$/.exec(property)) { // str with only A-z0-9_ chars display `foo.bar`
+					return (key !== 0) ? '.' + property : property;
+				} else {
+					property = property.replace(regexp, '\\$1');
+					return '[' + quote + property + quote + ']';
+				}
+			}).join('');
 		},
 
 		normalize: function(data, quote){

--- a/lib/ObjectPath.js
+++ b/lib/ObjectPath.js
@@ -3,7 +3,7 @@
 ;!function(undefined) {
 	var regex = {
 		"'": /\\\'/g,
-		'"': /\\\"/g
+		'"': /\\\"/g,
 	};
 
 	var ObjectPath = {
@@ -24,13 +24,11 @@
 					parts.push(str.slice(i, str.length));
 					i = str.length;
 				}
-
 				// dots
 				else if (bracket === -1 || (dot !== -1 && dot < bracket)) {
 					parts.push(str.slice(i, dot));
 					i = dot + 1;
 				}
-
 				// brackets
 				else {
 					if (bracket > i) {
@@ -38,14 +36,19 @@
 						i = bracket;
 					}
 					quote = str.slice(bracket + 1, bracket + 2);
-					if (quote !== '"' && quote !== '\'') {
+
+					if (quote !== '"' && quote !== "'") {
 						closing = str.indexOf(']', bracket);
-						if (closing === -1) closing = str.length;
+						if (closing === -1) {
+							closing = str.length;
+						}
 						parts.push(str.slice(i + 1, closing));
 						i = (str.slice(closing + 1, closing + 2) === '.') ? closing + 2 : closing + 1;
 					} else {
 						closing = str.indexOf(quote + ']', bracket);
-						if (closing === -1) closing = str.length;
+						if (closing === -1) {
+							closing = str.length;
+						}
 						while (str.slice(closing - 1, closing) === '\\' && bracket < str.length) {
 							bracket++;
 							closing = str.indexOf(quote + ']', bracket);

--- a/test/index.js
+++ b/test/index.js
@@ -53,21 +53,21 @@ describe('Stringify', function(){
 	});
 
 	it('stringifys a numberic nodes in bracket notation with single quotes', function(){
-		assert.deepEqual(ObjectPath.stringify(['5']), '[\'5\']', 'incorrectly stringified single headless numeric node');
-		assert.deepEqual(ObjectPath.stringify(['5','a','3']), '[\'5\'].a[\'3\']', 'incorrectly stringified headless numeric multi-node');
+		assert.deepEqual(ObjectPath.stringify(['5']), '[5]', 'incorrectly stringified single headless numeric node');
+		assert.deepEqual(ObjectPath.stringify(['5','a','3']), '[5].a[3]', 'incorrectly stringified headless numeric multi-node');
 	});
 
 	it('stringifys a numberic nodes in bracket notation with double quotes', function(){
-		assert.deepEqual(ObjectPath.stringify(['5'],'"'), '["5"]', 'incorrectly stringified single headless numeric node');
-		assert.deepEqual(ObjectPath.stringify(['5','a','3'],'"'), '["5"].a["3"]', 'incorrectly stringified headless numeric multi-node');
+		assert.deepEqual(ObjectPath.stringify(['5'],'"'), '[5]', 'incorrectly stringified single headless numeric node');
+		assert.deepEqual(ObjectPath.stringify(['5','a','3'],'"'), '[5].a[3]', 'incorrectly stringified headless numeric multi-node');
 	});
 
 	it('stringifys a combination of dot and bracket notation with single quotes', function(){
-		assert.deepEqual(ObjectPath.stringify(['a','1','b','c','d','e','f','g']), 'a[\'1\'].b.c.d.e.f.g');
+		assert.deepEqual(ObjectPath.stringify(['a','1','b','c','d','e','f','g']), 'a[1].b.c.d.e.f.g');
 	});
 
 	it('stringifys a combination of dot and bracket notation with double quotes', function(){
-		assert.deepEqual(ObjectPath.stringify(['a','1','b','c','d','e','f','g'],'"'), 'a["1"].b.c.d.e.f.g');
+		assert.deepEqual(ObjectPath.stringify(['a','1','b','c','d','e','f','g'],'"'), 'a[1].b.c.d.e.f.g');
 	});
 
 	it('stringifys unicode characters with single quotes', function(){

--- a/test/index.js
+++ b/test/index.js
@@ -47,6 +47,7 @@ describe('Stringify', function(){
 		assert.deepEqual(ObjectPath.stringify(['a'], '\''), 'a', 'incorrectly stringified single node with excplicit single quote');
 		assert.deepEqual(ObjectPath.stringify(['a','b','c'], '\''), 'a.b.c', 'incorrectly stringified multi-node with excplicit single quote');
 	});
+
 	it('stringifys simple paths with double quotes', function(){
 		assert.deepEqual(ObjectPath.stringify(['a'],'"'), 'a', 'incorrectly stringified single node');
 		assert.deepEqual(ObjectPath.stringify(['a','b','c'],'"'), 'a.b.c', 'incorrectly stringified multi-node');
@@ -64,10 +65,12 @@ describe('Stringify', function(){
 
 	it('stringifys a combination of dot and bracket notation with single quotes', function(){
 		assert.deepEqual(ObjectPath.stringify(['a','1','b','c','d','e','f','g']), 'a[1].b.c.d.e.f.g');
+		assert.deepEqual(ObjectPath.stringify(['a','1','b','c','d','e','f','g'],null,true), "['a']['1']['b']['c']['d']['e']['f']['g']");
 	});
 
 	it('stringifys a combination of dot and bracket notation with double quotes', function(){
 		assert.deepEqual(ObjectPath.stringify(['a','1','b','c','d','e','f','g'],'"'), 'a[1].b.c.d.e.f.g');
+		assert.deepEqual(ObjectPath.stringify(['a','1','b','c','d','e','f','g'],'"',true), '["a"]["1"]["b"]["c"]["d"]["e"]["f"]["g"]');
 	});
 
 	it('stringifys unicode characters with single quotes', function(){

--- a/test/index.js
+++ b/test/index.js
@@ -3,108 +3,161 @@
 var assert = require('chai').assert;
 var ObjectPath = require('../index.js');
 
+var parse = ObjectPath.parse;
+var stringify = ObjectPath.stringify;
+
 describe('Parse', function(){
 	it('parses simple paths in dot notation', function(){
-		assert.deepEqual(ObjectPath.parse('a'), ['a'], 'incorrectly parsed single node');
-		assert.deepEqual(ObjectPath.parse('a.b.c'), ['a','b','c'], 'incorrectly parsed multi-node');
+		assert.deepEqual(parse('a'), ['a'], 'incorrectly parsed single node');
+		assert.deepEqual(parse('a.b.c'), ['a','b','c'], 'incorrectly parsed multi-node');
 	});
 
 	it('parses simple paths in bracket notation', function(){
-		assert.deepEqual(ObjectPath.parse('["c"]'), ['c'], 'incorrectly parsed single headless node');
-		assert.deepEqual(ObjectPath.parse('a["b"]["c"]'), ['a','b','c'], 'incorrectly parsed multi-node');
-		assert.deepEqual(ObjectPath.parse('["a"]["b"]["c"]'), ['a','b','c'], 'incorrectly parsed headless multi-node');
+		assert.deepEqual(parse('["c"]'), ['c'], 'incorrectly parsed single headless node');
+		assert.deepEqual(parse('a["b"]["c"]'), ['a','b','c'], 'incorrectly parsed multi-node');
+		assert.deepEqual(parse('["a"]["b"]["c"]'), ['a','b','c'], 'incorrectly parsed headless multi-node');
 	});
 
 	it('parses a numberic nodes in bracket notation', function(){
-		assert.deepEqual(ObjectPath.parse('[5]'), ['5'], 'incorrectly parsed single headless numeric node');
-		assert.deepEqual(ObjectPath.parse('[5]["a"][3]'), ['5','a','3'], 'incorrectly parsed headless numeric multi-node');
+		assert.deepEqual(parse('[5]'), ['5'], 'incorrectly parsed single headless numeric node');
+		assert.deepEqual(parse('[5]["a"][3]'), ['5','a','3'], 'incorrectly parsed headless numeric multi-node');
 	});
 
 	it('parses a combination of dot and bracket notation', function(){
-		assert.deepEqual(ObjectPath.parse('a[1].b.c.d["e"]["f"].g'), ['a','1','b','c','d','e','f','g']);
+		assert.deepEqual(parse('a[1].b.c.d["e"]["f"].g'), ['a','1','b','c','d','e','f','g']);
 	});
 
 	it('parses unicode characters', function(){
-		assert.deepEqual(ObjectPath.parse('∑´ƒ©∫∆.ø'), ['∑´ƒ©∫∆','ø'], 'incorrectly parsed unicode characters from dot notation');
-		assert.deepEqual(ObjectPath.parse('["∑´ƒ©∫∆"]["ø"]'), ['∑´ƒ©∫∆','ø'], 'incorrectly parsed unicode characters from bracket notation');
+		assert.deepEqual(parse('∑´ƒ©∫∆.ø'), ['∑´ƒ©∫∆','ø'], 'incorrectly parsed unicode characters from dot notation');
+		assert.deepEqual(parse('["∑´ƒ©∫∆"]["ø"]'), ['∑´ƒ©∫∆','ø'], 'incorrectly parsed unicode characters from bracket notation');
 	});
 
 	it('parses nodes with control characters', function(){
-		assert.deepEqual(ObjectPath.parse('["a.b."]'), ['a.b.'], 'incorrectly parsed dots from inside brackets');
-		assert.deepEqual(ObjectPath.parse('["\""][\'\\\'\']'), ['"','\''], 'incorrectly parsed escaped quotes');
-		assert.deepEqual(ObjectPath.parse('["\'"][\'"\']'), ['\'','"'], 'incorrectly parsed unescaped quotes');
-		assert.deepEqual(ObjectPath.parse('["\\""][\'\\\'\']'), ['"','\''], 'incorrectly parsed escaped quotes');
-		assert.deepEqual(ObjectPath.parse('[\'\\"\']["\\\'"]'), ['\\"','\\\''], 'incorrectly parsed escape characters');
-		assert.deepEqual(ObjectPath.parse('["\\"]"]["\\"]\\"]"]'), ['"]','"]"]'], 'incorrectly parsed escape characters');
-		assert.deepEqual(ObjectPath.parse('["[\'a\']"][\'[\\"a\\"]\']'), ['[\'a\']','[\\"a\\"]'], 'incorrectly parsed escape character');
+		assert.deepEqual(parse('["a.b."]'), ['a.b.'], 'incorrectly parsed dots from inside brackets');
+		assert.deepEqual(parse('["\""][\'\\\'\']'), ['"','\''], 'incorrectly parsed escaped quotes');
+		assert.deepEqual(parse('["\'"][\'"\']'), ['\'','"'], 'incorrectly parsed unescaped quotes');
+		assert.deepEqual(parse('["\\""][\'\\\'\']'), ['"','\''], 'incorrectly parsed escaped quotes');
+		assert.deepEqual(parse('[\'\\"\']["\\\'"]'), ['\\"','\\\''], 'incorrectly parsed escape characters');
+		assert.deepEqual(parse('["\\"]"]["\\"]\\"]"]'), ['"]','"]"]'], 'incorrectly parsed escape characters');
+		assert.deepEqual(parse('["[\'a\']"][\'[\\"a\\"]\']'), ['[\'a\']','[\\"a\\"]'], 'incorrectly parsed escape character');
 	});
 });
 
 describe('Stringify', function(){
 	it('stringifys simple paths with single quotes', function(){
-		assert.deepEqual(ObjectPath.stringify(['a']), 'a', 'incorrectly stringified single node');
-		assert.deepEqual(ObjectPath.stringify(['a','b','c']), 'a.b.c', 'incorrectly stringified multi-node');
-		assert.deepEqual(ObjectPath.stringify(['a'], '\''), 'a', 'incorrectly stringified single node with excplicit single quote');
-		assert.deepEqual(ObjectPath.stringify(['a','b','c'], '\''), 'a.b.c', 'incorrectly stringified multi-node with excplicit single quote');
+		assert.deepEqual(stringify(['a']), 'a', 'incorrectly stringified single node');
+		assert.deepEqual(stringify(['a','b','c']), 'a.b.c', 'incorrectly stringified multi-node');
+		assert.deepEqual(stringify(['a'], '\''), 'a', 'incorrectly stringified single node with excplicit single quote');
+		assert.deepEqual(stringify(['a','b','c'], '\''), 'a.b.c', 'incorrectly stringified multi-node with excplicit single quote');
 	});
 
 	it('stringifys simple paths with double quotes', function(){
-		assert.deepEqual(ObjectPath.stringify(['a'],'"'), 'a', 'incorrectly stringified single node');
-		assert.deepEqual(ObjectPath.stringify(['a','b','c'],'"'), 'a.b.c', 'incorrectly stringified multi-node');
+		assert.deepEqual(stringify(['a'],'"'), 'a', 'incorrectly stringified single node');
+		assert.deepEqual(stringify(['a','b','c'],'"'), 'a.b.c', 'incorrectly stringified multi-node');
 	});
 
 	it('stringifys a numberic nodes in bracket notation with single quotes', function(){
-		assert.deepEqual(ObjectPath.stringify(['5']), '[5]', 'incorrectly stringified single headless numeric node');
-		assert.deepEqual(ObjectPath.stringify(['5','a','3']), '[5].a[3]', 'incorrectly stringified headless numeric multi-node');
+		assert.deepEqual(stringify(['5']), '[5]', 'incorrectly stringified single headless numeric node');
+		assert.deepEqual(stringify(['5','a','3']), '[5].a[3]', 'incorrectly stringified headless numeric multi-node');
 	});
 
 	it('stringifys a numberic nodes in bracket notation with double quotes', function(){
-		assert.deepEqual(ObjectPath.stringify(['5'],'"'), '[5]', 'incorrectly stringified single headless numeric node');
-		assert.deepEqual(ObjectPath.stringify(['5','a','3'],'"'), '[5].a[3]', 'incorrectly stringified headless numeric multi-node');
+		assert.deepEqual(stringify(['5'],'"'), '[5]', 'incorrectly stringified single headless numeric node');
+		assert.deepEqual(stringify(['5','a','3'],'"'), '[5].a[3]', 'incorrectly stringified headless numeric multi-node');
 	});
 
 	it('stringifys a combination of dot and bracket notation with single quotes', function(){
-		assert.deepEqual(ObjectPath.stringify(['a','1','b','c','d','e','f','g']), 'a[1].b.c.d.e.f.g');
-		assert.deepEqual(ObjectPath.stringify(['a','1','b','c','d','e','f','g'],null,true), "['a']['1']['b']['c']['d']['e']['f']['g']");
+		assert.deepEqual(stringify(['a','1','b','c','d','e','f','g']), 'a[1].b.c.d.e.f.g');
+		assert.deepEqual(stringify(['a','1','b','c','d','e','f','g'],null,true), "['a']['1']['b']['c']['d']['e']['f']['g']");
 	});
 
 	it('stringifys a combination of dot and bracket notation with double quotes', function(){
-		assert.deepEqual(ObjectPath.stringify(['a','1','b','c','d','e','f','g'],'"'), 'a[1].b.c.d.e.f.g');
-		assert.deepEqual(ObjectPath.stringify(['a','1','b','c','d','e','f','g'],'"',true), '["a"]["1"]["b"]["c"]["d"]["e"]["f"]["g"]');
+		assert.deepEqual(stringify(['a','1','b','c','d','e','f','g'],'"'), 'a[1].b.c.d.e.f.g');
+		assert.deepEqual(stringify(['a','1','b','c','d','e','f','g'],'"',true), '["a"]["1"]["b"]["c"]["d"]["e"]["f"]["g"]');
 	});
 
 	it('stringifys unicode characters with single quotes', function(){
-		assert.deepEqual(ObjectPath.stringify(['∑´ƒ©∫∆']), '[\'∑´ƒ©∫∆\']', 'incorrectly stringified single node path with unicode');
-		assert.deepEqual(ObjectPath.stringify(['∑´ƒ©∫∆','ø']), '[\'∑´ƒ©∫∆\'][\'ø\']', 'incorrectly stringified multi-node path with unicode characters');
+		assert.deepEqual(stringify(['∑´ƒ©∫∆']), '[\'∑´ƒ©∫∆\']', 'incorrectly stringified single node path with unicode');
+		assert.deepEqual(stringify(['∑´ƒ©∫∆','ø']), '[\'∑´ƒ©∫∆\'][\'ø\']', 'incorrectly stringified multi-node path with unicode characters');
 	});
 
 	it('stringifys unicode characters with double quotes', function(){
-		assert.deepEqual(ObjectPath.stringify(['∑´ƒ©∫∆'],'"'), '["∑´ƒ©∫∆"]', 'incorrectly stringified single node path with unicode');
-		assert.deepEqual(ObjectPath.stringify(['∑´ƒ©∫∆','ø'],'"'), '["∑´ƒ©∫∆"]["ø"]', 'incorrectly stringified multi-node path with unicode characters');
+		assert.deepEqual(stringify(['∑´ƒ©∫∆'],'"'), '["∑´ƒ©∫∆"]', 'incorrectly stringified single node path with unicode');
+		assert.deepEqual(stringify(['∑´ƒ©∫∆','ø'],'"'), '["∑´ƒ©∫∆"]["ø"]', 'incorrectly stringified multi-node path with unicode characters');
 	});
 
 	it("stringifys nodes with control characters and single quotes", function(){
-		assert.deepEqual(ObjectPath.stringify(["a.b."],"'"), "['a.b.']", "incorrectly stringified dots from inside brackets");
-		assert.deepEqual(ObjectPath.stringify(["'","\\\""],"'"), "['\\\'']['\\\\\"']", "incorrectly stringified escaped quotes");
-		assert.deepEqual(ObjectPath.stringify(["\"","'"],"'"), "['\"']['\\'']", "incorrectly stringified unescaped quotes");
-		assert.deepEqual(ObjectPath.stringify(["\\'","\\\""],"'"), "['\\\\\\'']['\\\\\"']", "incorrectly stringified escape character");
-		assert.deepEqual(ObjectPath.stringify(["[\"a\"]","[\\'a\\']"],"'"), "['[\"a\"]']['[\\\\\\'a\\\\\\']']", "incorrectly stringified escape character");
+		assert.deepEqual(stringify(["a.b."],"'"), "['a.b.']", "incorrectly stringified dots from inside brackets");
+		assert.deepEqual(stringify(["'","\\\""],"'"), "['\\\'']['\\\\\"']", "incorrectly stringified escaped quotes");
+		assert.deepEqual(stringify(["\"","'"],"'"), "['\"']['\\'']", "incorrectly stringified unescaped quotes");
+		assert.deepEqual(stringify(["\\'","\\\""],"'"), "['\\\\\\'']['\\\\\"']", "incorrectly stringified escape character");
+		assert.deepEqual(stringify(["[\"a\"]","[\\'a\\']"],"'"), "['[\"a\"]']['[\\\\\\'a\\\\\\']']", "incorrectly stringified escape character");
 	});
 	
 	it("stringifys nodes with backslash", function(){
 		const originalProperty = ' \\" \\\\" \\\\\\';
-		const path = ObjectPath.stringify([' \\" \\\\" \\\\\\'], '"');
+		const path = stringify([' \\" \\\\" \\\\\\'], '"');
 		const finalProperty = JSON.parse(path.substring(1, path.length - 1));
 
 		assert.deepEqual(finalProperty, originalProperty, 'incorrectly stringified escaped backslash');
 	});
 
 	it('stringifys nodes with control characters and double quotes', function(){
-		assert.deepEqual(ObjectPath.stringify(['a.b.'],'"'), '["a.b."]', 'incorrectly stringified dots from inside brackets');
-		assert.deepEqual(ObjectPath.stringify(['"','\\\''],'"'), '["\\\""]["\\\\\'"]', 'incorrectly stringified escaped quotes');
-		assert.deepEqual(ObjectPath.stringify(['\'','"'],'"'), '["\'"]["\\""]', 'incorrectly stringified unescaped quotes');
-		assert.deepEqual(ObjectPath.stringify(['\\"','\\\''],'"'), '["\\\\\\""]["\\\\\'"]', 'incorrectly stringified escape character');
-		assert.deepEqual(ObjectPath.stringify(['[\'a\']','[\\"a\\"]'],'"'), '["[\'a\']"]["[\\\\\\"a\\\\\\"]"]', 'incorrectly stringified escape character');
+		assert.deepEqual(stringify(['a.b.'],'"'), '["a.b."]', 'incorrectly stringified dots from inside brackets');
+		assert.deepEqual(stringify(['"','\\\''],'"'), '["\\\""]["\\\\\'"]', 'incorrectly stringified escaped quotes');
+		assert.deepEqual(stringify(['\'','"'],'"'), '["\'"]["\\""]', 'incorrectly stringified unescaped quotes');
+		assert.deepEqual(stringify(['\\"','\\\''],'"'), '["\\\\\\""]["\\\\\'"]', 'incorrectly stringified escape character');
+		assert.deepEqual(stringify(['[\'a\']','[\\"a\\"]'],'"'), '["[\'a\']"]["[\\\\\\"a\\\\\\"]"]', 'incorrectly stringified escape character');
+	});
+});
+
+describe('Backslash support tests', function(){
+	var property, expected;
+	function noBuckets(path) {
+		return path.replace(/^\[(.*)\]$/, '$1');
+	}
+	function digest(property) {
+		return stringify(parse(property), '"');
+	}
+
+	it('should escape a quote', function(){
+		assert.deepEqual(digest('a"'), String.raw`["a\""]`, 'incorrectly escape quote');
+	});
+
+	it('should escape backslash', function(){
+		assert.deepEqual(digest('lol\\\\eded.ededed.deede'), String.raw`["lol\\\\eded"].ededed.deede`, 'incorrectly escape quote');
+	});
+
+	it('should escape one backslash', function(){
+		property = String.raw`a\"`;
+		expected = String.raw`["a\\\""]`; // equivalent: expected = '["a\\\\\\""]'
+		assert.deepEqual(digest(property), expected, 'incorrectly escape single backslash');
+		assert.deepEqual(JSON.stringify(property), noBuckets(expected), 'incorrectly escape single backslash');
+	});
+
+	it('should escape several backslash', function(){
+		property = String.raw`a\\"`;
+		expected = String.raw`["a\\\\\""]`; // equivalent: expected = '["a\\\\\\""]'
+		assert.deepEqual(digest(property), expected, 'incorrectly escape several backslash');
+		assert.deepEqual(JSON.stringify(property), noBuckets(expected), 'incorrectly escape several backslash');
+		assert.deepEqual(digest(digest(digest(digest(property)))), expected, 'incorrectly escape after several stringify&parse on the same value');
+	});
+
+	it('should be a valid js path (accepted by ECMAScript)', function(){
+		property = String.raw`a\\"`;
+		expected = String.raw`["a\\\\\""]`; // equivalent: expected = '["a\\\\\\""]'
+		assert.deepEqual(digest(property), expected, 'invalid path syntax');
+		assert.doesNotThrow(function () {
+			try {
+				eval(digest(property)); // only with trusted string
+				return true;
+			} catch (e) {
+				if (e.message.indexOf("Cannot read property") !== -1) // mean undefined
+					return true;
+				else // Syntax error
+					throw new Error("wrong with ES");
+			}
+		}, 'invalid path syntax');
 	});
 });
 

--- a/test/index.js
+++ b/test/index.js
@@ -42,32 +42,32 @@ describe('Parse', function(){
 
 describe('Stringify', function(){
 	it('stringifys simple paths with single quotes', function(){
-		assert.deepEqual(ObjectPath.stringify(['a']), '[\'a\']', 'incorrectly stringified single node');
-		assert.deepEqual(ObjectPath.stringify(['a','b','c']), '[\'a\'][\'b\'][\'c\']', 'incorrectly stringified multi-node');
-		assert.deepEqual(ObjectPath.stringify(['a'], '\''), '[\'a\']', 'incorrectly stringified single node with excplicit single quote');
-		assert.deepEqual(ObjectPath.stringify(['a','b','c'], '\''), '[\'a\'][\'b\'][\'c\']', 'incorrectly stringified multi-node with excplicit single quote');
+		assert.deepEqual(ObjectPath.stringify(['a']), 'a', 'incorrectly stringified single node');
+		assert.deepEqual(ObjectPath.stringify(['a','b','c']), 'a.b.c', 'incorrectly stringified multi-node');
+		assert.deepEqual(ObjectPath.stringify(['a'], '\''), 'a', 'incorrectly stringified single node with excplicit single quote');
+		assert.deepEqual(ObjectPath.stringify(['a','b','c'], '\''), 'a.b.c', 'incorrectly stringified multi-node with excplicit single quote');
 	});
 	it('stringifys simple paths with double quotes', function(){
-		assert.deepEqual(ObjectPath.stringify(['a'],'"'), '["a"]', 'incorrectly stringified single node');
-		assert.deepEqual(ObjectPath.stringify(['a','b','c'],'"'), '["a"]["b"]["c"]', 'incorrectly stringified multi-node');
+		assert.deepEqual(ObjectPath.stringify(['a'],'"'), 'a', 'incorrectly stringified single node');
+		assert.deepEqual(ObjectPath.stringify(['a','b','c'],'"'), 'a.b.c', 'incorrectly stringified multi-node');
 	});
 
 	it('stringifys a numberic nodes in bracket notation with single quotes', function(){
 		assert.deepEqual(ObjectPath.stringify(['5']), '[\'5\']', 'incorrectly stringified single headless numeric node');
-		assert.deepEqual(ObjectPath.stringify(['5','a','3']), '[\'5\'][\'a\'][\'3\']', 'incorrectly stringified headless numeric multi-node');
+		assert.deepEqual(ObjectPath.stringify(['5','a','3']), '[\'5\'].a[\'3\']', 'incorrectly stringified headless numeric multi-node');
 	});
 
 	it('stringifys a numberic nodes in bracket notation with double quotes', function(){
 		assert.deepEqual(ObjectPath.stringify(['5'],'"'), '["5"]', 'incorrectly stringified single headless numeric node');
-		assert.deepEqual(ObjectPath.stringify(['5','a','3'],'"'), '["5"]["a"]["3"]', 'incorrectly stringified headless numeric multi-node');
+		assert.deepEqual(ObjectPath.stringify(['5','a','3'],'"'), '["5"].a["3"]', 'incorrectly stringified headless numeric multi-node');
 	});
 
 	it('stringifys a combination of dot and bracket notation with single quotes', function(){
-		assert.deepEqual(ObjectPath.stringify(['a','1','b','c','d','e','f','g']), '[\'a\'][\'1\'][\'b\'][\'c\'][\'d\'][\'e\'][\'f\'][\'g\']');
+		assert.deepEqual(ObjectPath.stringify(['a','1','b','c','d','e','f','g']), 'a[\'1\'].b.c.d.e.f.g');
 	});
 
 	it('stringifys a combination of dot and bracket notation with double quotes', function(){
-		assert.deepEqual(ObjectPath.stringify(['a','1','b','c','d','e','f','g'],'"'), '["a"]["1"]["b"]["c"]["d"]["e"]["f"]["g"]');
+		assert.deepEqual(ObjectPath.stringify(['a','1','b','c','d','e','f','g'],'"'), 'a["1"].b.c.d.e.f.g');
 	});
 
 	it('stringifys unicode characters with single quotes', function(){
@@ -82,29 +82,37 @@ describe('Stringify', function(){
 
 	it("stringifys nodes with control characters and single quotes", function(){
 		assert.deepEqual(ObjectPath.stringify(["a.b."],"'"), "['a.b.']", "incorrectly stringified dots from inside brackets");
-		assert.deepEqual(ObjectPath.stringify(["'","\\\""],"'"), "['\\\'']['\\\"']", "incorrectly stringified escaped quotes");
+		assert.deepEqual(ObjectPath.stringify(["'","\\\""],"'"), "['\\\'']['\\\\\"']", "incorrectly stringified escaped quotes");
 		assert.deepEqual(ObjectPath.stringify(["\"","'"],"'"), "['\"']['\\'']", "incorrectly stringified unescaped quotes");
-		assert.deepEqual(ObjectPath.stringify(["\\'","\\\""],"'"), "['\\\\'']['\\\"']", "incorrectly stringified escape character");
-		assert.deepEqual(ObjectPath.stringify(["[\"a\"]","[\\'a\\']"],"'"), "['[\"a\"]']['[\\\\'a\\\\']']", "incorrectly stringified escape character");
+		assert.deepEqual(ObjectPath.stringify(["\\'","\\\""],"'"), "['\\\\\\'']['\\\\\"']", "incorrectly stringified escape character");
+		assert.deepEqual(ObjectPath.stringify(["[\"a\"]","[\\'a\\']"],"'"), "['[\"a\"]']['[\\\\\\'a\\\\\\']']", "incorrectly stringified escape character");
+	});
+	
+	it("stringifys nodes with backslash", function(){
+		const originalProperty = ' \\" \\\\" \\\\\\';
+		const path = ObjectPath.stringify([' \\" \\\\" \\\\\\'], '"');
+		const finalProperty = JSON.parse(path.substring(1, path.length - 1));
+
+		assert.deepEqual(finalProperty, originalProperty, 'incorrectly stringified escaped backslash');
 	});
 
 	it('stringifys nodes with control characters and double quotes', function(){
 		assert.deepEqual(ObjectPath.stringify(['a.b.'],'"'), '["a.b."]', 'incorrectly stringified dots from inside brackets');
-		assert.deepEqual(ObjectPath.stringify(['"','\\\''],'"'), '["\\\""]["\\\'"]', 'incorrectly stringified escaped quotes');
+		assert.deepEqual(ObjectPath.stringify(['"','\\\''],'"'), '["\\\""]["\\\\\'"]', 'incorrectly stringified escaped quotes');
 		assert.deepEqual(ObjectPath.stringify(['\'','"'],'"'), '["\'"]["\\""]', 'incorrectly stringified unescaped quotes');
-		assert.deepEqual(ObjectPath.stringify(['\\"','\\\''],'"'), '["\\\\""]["\\\'"]', 'incorrectly stringified escape character');
-		assert.deepEqual(ObjectPath.stringify(['[\'a\']','[\\"a\\"]'],'"'), '["[\'a\']"]["[\\\\"a\\\\"]"]', 'incorrectly stringified escape character');
+		assert.deepEqual(ObjectPath.stringify(['\\"','\\\''],'"'), '["\\\\\\""]["\\\\\'"]', 'incorrectly stringified escape character');
+		assert.deepEqual(ObjectPath.stringify(['[\'a\']','[\\"a\\"]'],'"'), '["[\'a\']"]["[\\\\\\"a\\\\\\"]"]', 'incorrectly stringified escape character');
 	});
 });
 
 describe('Normalize', function(){
 	it('normalizes a string', function(){
-		assert.deepEqual(ObjectPath.normalize('a.b["c"]'), '[\'a\'][\'b\'][\'c\']', 'incorrectly normalized a string with single quotes');
-		assert.deepEqual(ObjectPath.normalize('a.b["c"]','"'), '["a"]["b"]["c"]', 'incorrectly normalized a string with double quotes');
+		assert.deepEqual(ObjectPath.normalize('a.b["c"]'), 'a.b.c', 'incorrectly normalized a string with single quotes');
+		assert.deepEqual(ObjectPath.normalize('a.b["c"]','"'), 'a.b.c', 'incorrectly normalized a string with double quotes');
 	});
 
 	it('normalizes an array', function(){
-		assert.deepEqual(ObjectPath.normalize(['a','b','c']), '[\'a\'][\'b\'][\'c\']', 'incorrectly normalized an array with single quotes');
-		assert.deepEqual(ObjectPath.normalize(['a','b','c'],'"'), '["a"]["b"]["c"]', 'incorrectly normalized an array with double quotes');
+		assert.deepEqual(ObjectPath.normalize(['a','b','c']), 'a.b.c', 'incorrectly normalized an array with single quotes');
+		assert.deepEqual(ObjectPath.normalize(['a','b','c'],'"'), 'a.b.c', 'incorrectly normalized an array with double quotes');
 	});
 });


### PR DESCRIPTION
 - Fix error/oversight: backslash was not escaped. fix: #14, fix: #16
 - Property name is scoped in `["..."]` only with special char (other than A-z0-9_) or is started with a number.

# Before : 
```js
// JSON.stringify:
dico = {
  "a\"": 0,
  "a\\\"": 1,
  "a\\\\\"": 2,
  "end": true
}
// ObjectPath.stringify&parse:
a" path : ["a\""] is good
a\" path : ["a\\""] is wrong expected: a\\\" got: a\\"
a\\" path : ["a\\\""] is wrong expected: a\\\\\" got: a\\\"
```

# After (with this PR) : 
```js
// JSON.stringify:
dico = {
  "a\"": 0,
  "a\\\"": 1,
  "a\\\\\"": 2,
  "end": true
}
// ObjectPath.stringify&parse:
a" path : ["a\""] is good
a\" path : ["a\\\""] is good
a\\" path : ["a\\\\\""] is good
```
<details>
  <summary>Test script</summary>
  
```javascript
const parse = require('./').parse
const stringify = require('./').stringify

const list = [
  'a"',
  'a\\"',
  'a\\\\\"'
]

// vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
// v v v v v v v v OUTPUT SCRIPTS FOR TESTS v v v v v v v v
//  v v v v v v v  OUTPUT SCRIPTS FOR TESTS  v v v v v v v 
// v v v v v v v v OUTPUT SCRIPTS FOR TESTS v v v v v v v v
// vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv

const expected = (() => {
  const dico = {}

  list.forEach((prop, index) => {
    dico[prop] = index
  });
  dico.end = true

  return JSON.stringify(dico, null, 2)
})()

console.log("dico =", expected)

list.forEach((before, index) => {
  after = stringify(parse(before), '"')
  console.log(before, "path :", after, "is", testPath(after, index))
})

function testPath(path, index) {
  // Regex test: Should be the same value of JSON.stringify output
  const name = path.replace(/^\["(.*)"\]$/, '$1')
  if (!expected.includes(`\n  "${name}": ${index},`)) {
    return "wrong expected: " + expected.match(new RegExp(`\\n  "(.+)"\: ${index},\\n`))[1] + " got: " + name;
  }

  //  ECMAScript test (with eval): Should not throw
  try {
    eval(path)
    return "good"
  } catch (e) {
    if (e.message.indexOf("Cannot read property") !== -1)
      return "good"
    else
      return "wrong with ES"
  }
}
```
  
</details>