### PR TITLE
Add travis jobs on ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,10 @@
 language: node_js
+
+arch:
+ - amd64
+ - ppc64le
+ 
+ 
 node_js:
   - "6"
   - "8"


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) support on travis-ci in the branch and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.

https://travis-ci.com/github/manish364824/objectpath/builds/199882614

Please have a look.

Regards,
Manish